### PR TITLE
fix: build natively on arm64 hosts (closes #11)

### DIFF
--- a/.devcontainer/library-scripts/cloud-cli-tools.sh
+++ b/.devcontainer/library-scripts/cloud-cli-tools.sh
@@ -13,6 +13,23 @@ set -euo pipefail
 #     https://learn.microsoft.com/cli/azure/install-azure-cli-linux?pivots=apt
 #   - Google Cloud SDK: dearmor the apt key into /usr/share/keyrings and
 #     reference it via `signed-by=`, replacing the deprecated `apt-key add`.
+#
+# Architecture support (2026-06):
+#   Detect the build host arch via `dpkg --print-architecture` and pick
+#   per-tool naming. This lets the same Dockerfile build natively on amd64
+#   and arm64 (e.g. Apple Silicon) without producing a mixed-arch image.
+DPKG_ARCH="$(dpkg --print-architecture)"
+case "${DPKG_ARCH}" in
+    amd64) ;;
+    arm64) ;;
+    *) echo "Unsupported architecture: ${DPKG_ARCH}" >&2; exit 1 ;;
+esac
+
+# AWS CLI v2 installer uses x86_64 / aarch64 (Linux kernel naming).
+case "${DPKG_ARCH}" in
+    amd64) AWSCLI_ARCH="x86_64" ;;
+    arm64) AWSCLI_ARCH="aarch64" ;;
+esac
 
 # Always clean up tmp artifacts on exit (success or failure)
 cleanup() {
@@ -21,9 +38,9 @@ cleanup() {
 trap cleanup EXIT
 
 # Install AWS CLI v2
-echo "Installing AWS CLI v2..."
-curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip.sig" -o /tmp/awscliv2.sig
+echo "Installing AWS CLI v2 (${AWSCLI_ARCH})..."
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" -o /tmp/awscliv2.zip
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip.sig" -o /tmp/awscliv2.sig
 
 # Pinned AWS CLI Team OpenPGP public key (RSA 4096, key id A6310ACC4672475C).
 # This block is reproduced verbatim from the AWS CLI install docs so that the
@@ -75,7 +92,7 @@ echo "Installing Azure CLI..."
 curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
     | sudo gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
 AZ_REPO="$(lsb_release -cs)"
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ ${AZ_REPO} main" \
+echo "deb [arch=${DPKG_ARCH} signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ ${AZ_REPO} main" \
     | sudo tee /etc/apt/sources.list.d/azure-cli.list > /dev/null
 sudo apt-get update
 sudo apt-get install -y azure-cli

--- a/.devcontainer/library-scripts/terraform-tools.sh
+++ b/.devcontainer/library-scripts/terraform-tools.sh
@@ -16,6 +16,27 @@ set -euo pipefail
 #   posture. For HashiCorp tools an additional GPG verification of
 #   *_SHA256SUMS.sig is possible but is intentionally out of scope here.
 #
+# Architecture support (2026-06):
+#   The build host's architecture is detected once via `dpkg --print-architecture`
+#   and every download URL / checksum lookup is constructed accordingly. This
+#   lets the same Dockerfile build natively on amd64 (linux/amd64) and arm64
+#   (linux/arm64, e.g. Apple Silicon) without producing a mixed-arch image.
+DPKG_ARCH="$(dpkg --print-architecture)"
+case "${DPKG_ARCH}" in
+    amd64) ;;
+    arm64) ;;
+    *) echo "Unsupported architecture: ${DPKG_ARCH}" >&2; exit 1 ;;
+esac
+
+# Per-tool arch-name mappings. Most tools use the dpkg form (amd64 / arm64),
+# Terrascan uses Linux_x86_64 vs Linux_arm64 (only the amd64 form differs).
+TF_ARCH="${DPKG_ARCH}"               # terraform, tflint, terragrunt: linux_${TF_ARCH}
+TFDOCS_ARCH="${DPKG_ARCH}"           # terraform-docs, infracost, tfsec, Go: linux-${TFDOCS_ARCH}
+case "${DPKG_ARCH}" in
+    amd64) TERRASCAN_ARCH="x86_64" ;;
+    arm64) TERRASCAN_ARCH="arm64" ;;
+esac
+
 # Versions (do not change defaults — Dockerfile passes 12 positional args)
 TERRAFORM_VERSION=${1:-"1.12.1"}
 TERRAFORM_DOCS_VERSION=${2:-"0.20.0"}
@@ -30,10 +51,15 @@ TERRATEST_VERSION=${10:-"0.49.0"}
 INFRACOST_VERSION=${11:-"0.10.41"}
 CHECKOV_VERSION=${12:-"3.2.439"}
 
-# Pinned Go version used to back terratest. The SHA256 is taken from
-# https://go.dev/dl/?mode=json&include=all (file go1.20.5.linux-amd64.tar.gz).
+# Pinned Go version used to back terratest. SHA256s are from
+# https://go.dev/dl/?mode=json&include=all (linux archive for each arch).
 GO_VERSION="1.20.5"
 GO_LINUX_AMD64_SHA256="d7ec48cde0d3d2be2c69203bc3e0a44de8660b9c09a6e85c4732a3f7dc442612"
+GO_LINUX_ARM64_SHA256="aa2fab0a7da20213ff975fa7876a66d47b48351558d98851b87d1cfef4360d09"
+case "${DPKG_ARCH}" in
+    amd64) GO_SHA256="${GO_LINUX_AMD64_SHA256}" ;;
+    arm64) GO_SHA256="${GO_LINUX_ARM64_SHA256}" ;;
+esac
 
 # Always clear the workspace tmp on exit so a partial download never lingers
 cleanup() {
@@ -77,86 +103,86 @@ verify_from_sums_file() {
 
 echo "Installing Terraform v${TERRAFORM_VERSION}..."
 curl -fsSL -o /tmp/terraform.zip \
-    "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+    "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TF_ARCH}.zip"
 curl -fsSL -o /tmp/terraform_SHA256SUMS \
     "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS"
 verify_from_sums_file /tmp/terraform.zip \
-    "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" /tmp/terraform_SHA256SUMS
+    "terraform_${TERRAFORM_VERSION}_linux_${TF_ARCH}.zip" /tmp/terraform_SHA256SUMS
 unzip -qq /tmp/terraform.zip -d /tmp
 sudo mv /tmp/terraform /usr/local/bin/
 
 echo "Installing terraform-docs v${TERRAFORM_DOCS_VERSION}..."
 curl -fsSL -o /tmp/terraform-docs.tar.gz \
-    "https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz"
+    "https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-${TFDOCS_ARCH}.tar.gz"
 curl -fsSL -o /tmp/terraform-docs.sha256sum \
     "https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}.sha256sum"
 verify_from_sums_file /tmp/terraform-docs.tar.gz \
-    "terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz" /tmp/terraform-docs.sha256sum
+    "terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-${TFDOCS_ARCH}.tar.gz" /tmp/terraform-docs.sha256sum
 tar -xzf /tmp/terraform-docs.tar.gz -C /tmp
 sudo mv /tmp/terraform-docs /usr/local/bin/
 
 echo "Installing tfsec v${TFSEC_VERSION}..."
 curl -fsSL -o /tmp/tfsec \
-    "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64"
+    "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-${TFDOCS_ARCH}"
 curl -fsSL -o /tmp/tfsec_checksums.txt \
     "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec_checksums.txt"
-verify_from_sums_file /tmp/tfsec "tfsec-linux-amd64" /tmp/tfsec_checksums.txt
+verify_from_sums_file /tmp/tfsec "tfsec-linux-${TFDOCS_ARCH}" /tmp/tfsec_checksums.txt
 sudo mv /tmp/tfsec /usr/local/bin/
 sudo chmod +x /usr/local/bin/tfsec
 
 echo "Installing terrascan v${TERRASCAN_VERSION}..."
 curl -fsSL -o /tmp/terrascan.tar.gz \
-    "https://github.com/tenable/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz"
+    "https://github.com/tenable/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_${TERRASCAN_ARCH}.tar.gz"
 curl -fsSL -o /tmp/terrascan_checksums.txt \
     "https://github.com/tenable/terrascan/releases/download/v${TERRASCAN_VERSION}/checksums.txt"
 verify_from_sums_file /tmp/terrascan.tar.gz \
-    "terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz" /tmp/terrascan_checksums.txt
+    "terrascan_${TERRASCAN_VERSION}_Linux_${TERRASCAN_ARCH}.tar.gz" /tmp/terrascan_checksums.txt
 tar -xzf /tmp/terrascan.tar.gz -C /tmp
 sudo mv /tmp/terrascan /usr/local/bin/
 
 echo "Installing tflint v${TFLINT_VERSION}..."
 curl -fsSL -o /tmp/tflint.zip \
-    "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip"
+    "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_${TF_ARCH}.zip"
 curl -fsSL -o /tmp/tflint_checksums.txt \
     "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/checksums.txt"
-verify_from_sums_file /tmp/tflint.zip "tflint_linux_amd64.zip" /tmp/tflint_checksums.txt
+verify_from_sums_file /tmp/tflint.zip "tflint_linux_${TF_ARCH}.zip" /tmp/tflint_checksums.txt
 unzip -qq /tmp/tflint.zip -d /tmp
 sudo mv /tmp/tflint /usr/local/bin/
 
 echo "Installing TFLint AWS ruleset v${TFLINT_AWS_RULESET_VERSION}..."
 mkdir -p ~/.tflint.d/plugins
 curl -fsSL -o /tmp/tflint-aws-ruleset.zip \
-    "https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v${TFLINT_AWS_RULESET_VERSION}/tflint-ruleset-aws_linux_amd64.zip"
+    "https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v${TFLINT_AWS_RULESET_VERSION}/tflint-ruleset-aws_linux_${TF_ARCH}.zip"
 curl -fsSL -o /tmp/tflint-aws-ruleset_checksums.txt \
     "https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v${TFLINT_AWS_RULESET_VERSION}/checksums.txt"
 verify_from_sums_file /tmp/tflint-aws-ruleset.zip \
-    "tflint-ruleset-aws_linux_amd64.zip" /tmp/tflint-aws-ruleset_checksums.txt
+    "tflint-ruleset-aws_linux_${TF_ARCH}.zip" /tmp/tflint-aws-ruleset_checksums.txt
 unzip -qq /tmp/tflint-aws-ruleset.zip -d ~/.tflint.d/plugins
 
 echo "Installing TFLint Azure ruleset v${TFLINT_AZURE_RULESET_VERSION}..."
 curl -fsSL -o /tmp/tflint-azure-ruleset.zip \
-    "https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/download/v${TFLINT_AZURE_RULESET_VERSION}/tflint-ruleset-azurerm_linux_amd64.zip"
+    "https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/download/v${TFLINT_AZURE_RULESET_VERSION}/tflint-ruleset-azurerm_linux_${TF_ARCH}.zip"
 curl -fsSL -o /tmp/tflint-azure-ruleset_checksums.txt \
     "https://github.com/terraform-linters/tflint-ruleset-azurerm/releases/download/v${TFLINT_AZURE_RULESET_VERSION}/checksums.txt"
 verify_from_sums_file /tmp/tflint-azure-ruleset.zip \
-    "tflint-ruleset-azurerm_linux_amd64.zip" /tmp/tflint-azure-ruleset_checksums.txt
+    "tflint-ruleset-azurerm_linux_${TF_ARCH}.zip" /tmp/tflint-azure-ruleset_checksums.txt
 unzip -qq /tmp/tflint-azure-ruleset.zip -d ~/.tflint.d/plugins
 
 echo "Installing TFLint GCP ruleset v${TFLINT_GCP_RULESET_VERSION}..."
 curl -fsSL -o /tmp/tflint-gcp-ruleset.zip \
-    "https://github.com/terraform-linters/tflint-ruleset-google/releases/download/v${TFLINT_GCP_RULESET_VERSION}/tflint-ruleset-google_linux_amd64.zip"
+    "https://github.com/terraform-linters/tflint-ruleset-google/releases/download/v${TFLINT_GCP_RULESET_VERSION}/tflint-ruleset-google_linux_${TF_ARCH}.zip"
 curl -fsSL -o /tmp/tflint-gcp-ruleset_checksums.txt \
     "https://github.com/terraform-linters/tflint-ruleset-google/releases/download/v${TFLINT_GCP_RULESET_VERSION}/checksums.txt"
 verify_from_sums_file /tmp/tflint-gcp-ruleset.zip \
-    "tflint-ruleset-google_linux_amd64.zip" /tmp/tflint-gcp-ruleset_checksums.txt
+    "tflint-ruleset-google_linux_${TF_ARCH}.zip" /tmp/tflint-gcp-ruleset_checksums.txt
 unzip -qq /tmp/tflint-gcp-ruleset.zip -d ~/.tflint.d/plugins
 
 echo "Installing Terragrunt v${TERRAGRUNT_VERSION}..."
 curl -fsSL -o /tmp/terragrunt \
-    "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64"
+    "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TF_ARCH}"
 curl -fsSL -o /tmp/terragrunt_SHA256SUMS \
     "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/SHA256SUMS"
-verify_from_sums_file /tmp/terragrunt "terragrunt_linux_amd64" /tmp/terragrunt_SHA256SUMS
+verify_from_sums_file /tmp/terragrunt "terragrunt_linux_${TF_ARCH}" /tmp/terragrunt_SHA256SUMS
 sudo mv /tmp/terragrunt /usr/local/bin/
 sudo chmod +x /usr/local/bin/terragrunt
 
@@ -167,8 +193,8 @@ echo "export TERRATEST_VERSION=${TERRATEST_VERSION}" >> /home/vscode/.bashrc
 # Install Go if not already installed
 if ! command -v go &> /dev/null; then
     echo "Installing Go v${GO_VERSION} (required for Terratest)..."
-    curl -fsSL -o /tmp/go.tar.gz "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz"
-    verify_sha256 /tmp/go.tar.gz "${GO_LINUX_AMD64_SHA256}"
+    curl -fsSL -o /tmp/go.tar.gz "https://golang.org/dl/go${GO_VERSION}.linux-${TFDOCS_ARCH}.tar.gz"
+    verify_sha256 /tmp/go.tar.gz "${GO_SHA256}"
     sudo tar -C /usr/local -xzf /tmp/go.tar.gz
     echo 'export PATH=$PATH:/usr/local/go/bin' >> /home/vscode/.bashrc
     echo 'export PATH=$PATH:$HOME/go/bin' >> /home/vscode/.bashrc
@@ -187,14 +213,14 @@ sudo chmod +x /usr/local/bin/terratest
 
 echo "Installing Infracost v${INFRACOST_VERSION}..."
 curl -fsSL -o /tmp/infracost.tar.gz \
-    "https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-amd64.tar.gz"
+    "https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-${TFDOCS_ARCH}.tar.gz"
 curl -fsSL -o /tmp/infracost.tar.gz.sha256 \
-    "https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-amd64.tar.gz.sha256"
+    "https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-${TFDOCS_ARCH}.tar.gz.sha256"
 # Infracost publishes a single-line per-asset .sha256 in `<sum>  <filename>` form.
 verify_from_sums_file /tmp/infracost.tar.gz \
-    "infracost-linux-amd64.tar.gz" /tmp/infracost.tar.gz.sha256
+    "infracost-linux-${TFDOCS_ARCH}.tar.gz" /tmp/infracost.tar.gz.sha256
 tar -xzf /tmp/infracost.tar.gz -C /tmp
-sudo mv /tmp/infracost-linux-amd64 /usr/local/bin/infracost
+sudo mv "/tmp/infracost-linux-${TFDOCS_ARCH}" /usr/local/bin/infracost
 
 echo "Installing Checkov v${CHECKOV_VERSION}..."
 pip3 install "checkov==${CHECKOV_VERSION}"


### PR DESCRIPTION
## Summary

Make the devcontainer build natively on arm64 hosts (Apple Silicon). Currently every tool URL in `library-scripts/` is hardcoded `linux_amd64` / `linux-amd64` / `Linux_x86_64`, so a native arm64 build produces an image whose binaries can't run.

Closes #11. Re-addresses #3 (closed 2025-06-10, but the install scripts themselves were never made arch-aware).

## Reproducer (from issue #11)

Building this devcontainer in JetBrains 2024.1+ or VS Code on Apple Silicon fails at:

```
/usr/local/bin/terraform-docs: cannot execute binary file: Exec format error
make[2]: *** [.../terraform-docs.mk:29: terraform-docs/version] Error 126
```

Symptom is the same for every tool — first one invoked just happens to be `terraform-docs/version`.

## Fix

Detect arch once at the top of each install script and pick the right asset name per tool:

| Tool | amd64 form | arm64 form |
|------|-----------|-----------|
| terraform / tflint / tflint-rulesets / terragrunt | `linux_amd64` | `linux_arm64` |
| terraform-docs / tfsec / infracost / Go | `linux-amd64` | `linux-arm64` |
| terrascan | `Linux_x86_64` | `Linux_arm64` |
| AWS CLI v2 | `linux-x86_64` | `linux-aarch64` |
| Azure CLI apt source | `arch=amd64` | `arch=arm64` |
| gcloud | (no arch in source line, unchanged) |

The existing SHA256 verification is reused — only the basenames passed into `verify_from_sums_file` become arch-aware. The Go tarball (the only download verified against a pinned constant rather than a published checksum file) gains a separate `GO_LINUX_ARM64_SHA256`.

## Asset existence verified

For every pinned tool version, the arm64 release asset exists upstream — confirmed via `gh api repos/<owner>/<tool>/releases/tags/v<version>` for the GitHub-hosted releases, the HashiCorp `SHA256SUMS` file for terraform, `go.dev/dl/?mode=json&include=all` for Go, `https://packages.microsoft.com/repos/azure-cli/dists/jammy/main/binary-arm64/Packages.gz` (HTTP 200) for Azure CLI, and `https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip` (HTTP 200) for AWS CLI v2.

## Branch base

This branch is based on `feat/security-dx-2026-06` (PR #16) so it reuses the SHA-verify helpers introduced there. If PR #16 merges first, this rebases trivially. If you'd prefer to land this PR first, I can rebase it onto `main` directly — the install scripts on main don't have the helpers, so the arch logic still works but without verification (which is strictly worse than the version on this branch).

## Test plan

- [ ] CI `Docker Image CI` (build.yml) passes on the default amd64 runner — arch detection should resolve identically to the previous hardcoded paths
- [ ] Manual: `docker buildx build --platform linux/arm64 .` succeeds locally on Apple Silicon
- [ ] Manual: `docker buildx build --platform linux/amd64 .` still succeeds
- [ ] Manual: open the repo in JetBrains/VS Code on an Apple Silicon host with native build — the Exec format error from issue #11 no longer reproduces
- [ ] Spot-check `bash -n` on both modified scripts (verified locally)
- [ ] Multi-arch manifest publishing in CI is out of scope; this PR enables native builds but doesn't yet add `docker buildx build --platform linux/amd64,linux/arm64 --push`

## Out of scope

- CI multi-arch image publishing (`docker buildx` matrix in `build.yml`) — separate concern.
- Tracking arm64 binaries in `tools.env` if it pins amd64-only constants — checked, no arch strings in `tools.env`.