### PR TITLE
docs: overhaul documentation to AWS style guide

### DIFF
--- a/Makefile.md
+++ b/Makefile.md
@@ -1,6 +1,33 @@
-## Make
+# Make targets
 
+The `Makefile` in this repository is small. It inherits its targets from the [aws-code-habits](https://github.com/awslabs/aws-code-habits) submodule mounted under `habits/`:
+
+```makefile
+export WORKSPACE = $(shell pwd)
+export HABITS    = $(WORKSPACE)/habits
+
+include $(WORKSPACE)/tools.env
+include $(HABITS)/lib/make/Makefile
+include $(HABITS)/lib/make/*/Makefile
 ```
+
+You must initialize the submodule before any `make` target runs. If you cloned without `--recurse-submodules`, run:
+
+```bash
+git submodule update --init --recursive
+```
+
+To list the available targets, run:
+
+```bash
+make help
+```
+
+## Available targets
+
+The list below is the output of `make help` after the submodule is initialized. The targets come from `aws-code-habits`. This repository's continuous integration (CI) exercises only a subset of them — the install and `doc/build` targets used in `.github/workflows/test.yml` and `.github/workflows/hygiene.yml`. Treat the rest as best-effort.
+
+```text
 Available targets:
 
   aws/cfn-lint/install                Install AWS CloudFormation Linter
@@ -94,5 +121,6 @@ Available targets:
   tfswitch/version                    Display tfswitch version
   ubuntu/install                      Install most common packages
   ubuntu/update                       Update and upgrade Ubuntu packages
-
 ```
+
+> **Note:** This list is generated from the `aws-code-habits` submodule. When the submodule updates, the available targets can change. Run `make help` for the current list.

--- a/README.md
+++ b/README.md
@@ -1,424 +1,220 @@
-<img src="doc/logo.png" alt="Terraform Development Environment Logo" width="200"/>
+<img src="doc/logo.png" alt="Terraform Development Environment logo" width="200"/>
 
 # Terraform Development Environment
 
-[![GitHub stars](https://img.shields.io/github/stars/awslabs/aws-terraform-dev-container?style=social)](https://github.com/awslabs/aws-terraform-dev-container/stargazers)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Latest Release](https://img.shields.io/github/v/release/awslabs/aws-terraform-dev-container)](https://github.com/awslabs/aws-terraform-dev-container/releases)
+A Visual Studio Code dev container that gives you a pre-configured environment for developing, testing, and deploying Terraform infrastructure as code across AWS, Microsoft Azure, and Google Cloud Platform (GCP).
 
-A comprehensive VS Code Dev Container providing a consistent, pre-configured environment for developing, testing, and deploying infrastructure as code with Terraform across AWS, Azure, and GCP.
+[![License: MIT-0](https://img.shields.io/badge/License-MIT--0-yellow.svg)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/awslabs/aws-terraform-dev-container)](https://github.com/awslabs/aws-terraform-dev-container/releases)
 
-> **Boost your infrastructure development productivity with a ready-to-use, standardized environment that works the same way for everyone on your team, across all major cloud providers.**
+## Overview
 
-## Quick Links
+This repository packages a [Visual Studio Code dev container](https://code.visualstudio.com/docs/devcontainers/containers) for Terraform development. When you open the repository in VS Code and reopen it in the container, you get a Docker image with Terraform, the AWS, Azure, and GCP command line interfaces, and a suite of Terraform linting, security, testing, and cost-estimation tools already installed and pinned to known versions.
 
-- [Features](#-features) | [Prerequisites](#-prerequisites) | [Getting Started](#-getting-started)
-- [Tools](#-tools) | [Authentication](#-authentication) | [Configuration](#️-configuration)
-- [Contributing](#-contributing) | [License](#-license) | [Getting Help](#-getting-help)
+The container addresses the setup and consistency problems that come with infrastructure as code work: every contributor runs the same tool versions, credential directories are mounted from the host instead of stored in the image, and pre-commit hooks enforce formatting and security scanning before code is committed. It is intended for infrastructure engineers, platform teams, and anyone learning Terraform who wants a reproducible environment without installing tools on the host.
 
----
+The image targets Linux containers on the `linux/amd64` and `linux/arm64` architectures.
 
-## 🔍 The Problem We're Solving
+## Features
 
-Infrastructure as code (IaC) development with Terraform presents several challenges:
+- Multi-cloud command line tooling: AWS CLI v2, Azure CLI, and Google Cloud SDK.
+- Terraform and supporting tools: `terraform`, `terraform-docs`, `tflint` (with AWS, Azure, and GCP rulesets), `tfsec`, `terrascan`, `terragrunt`, Terratest, `infracost`, `checkov`, and `pre-commit`.
+- VS Code integration: pre-installed extensions, editor settings, and tasks for common Terraform and authentication workflows.
+- Pre-commit hooks for Terraform formatting, validation, documentation, security scanning, and secret detection.
+- Host credential mounts for AWS, Azure, GCP, and SSH, so credentials stay on the host.
+- A persistent Terraform plugin cache to speed up repeated `terraform init` runs.
 
-- **Environment Setup Complexity**: Time-consuming and error-prone setup process
-- **Cross-Cloud Development**: Managing different CLIs and authentication methods
-- **Security and Compliance**: Ensuring code meets security standards
-- **Team Consistency**: Maintaining consistent environments across team members
-- **Onboarding Friction**: New team members often spend days configuring their environment
+## Prerequisites
 
-This development container solves these problems by providing a ready-to-use, standardized environment with all necessary tools pre-configured.
+- [Docker](https://www.docker.com/products/docker-desktop/) — runs the container.
+- [Visual Studio Code](https://code.visualstudio.com/) — the supported editor.
+- The [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) (included in the [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)).
+- [Git](https://git-scm.com/) — clones the repository and its submodule.
 
----
+## Installation
 
-## 🌟 Features
+You can use the dev container in two ways: open this repository directly, or add the container to an existing Terraform project.
 
-- ☁️ **Multi-cloud Support**: Pre-installed CLIs and tools for AWS, Azure, and GCP
-- 🛠️ **Complete Terraform Ecosystem**: Comprehensive suite of tools including terraform-docs, tflint, tfsec, and more
-- 🔒 **Security and Compliance**: Pre-commit hooks for security scanning and compliance checking
-- 💻 **Enhanced Developer Experience**: VS Code integration with tasks, settings, and extensions
-- ⚡ **Performance Optimization**: Caching strategies and optimized volume mounts
-- 🧪 **Testing and Validation**: Built-in tools for testing infrastructure code
-- 💰 **Cost Management**: Integrated cost estimation with Infracost
+### Open this repository
 
----
+Clone the repository with submodules. The `Makefile` depends on the bundled [aws-code-habits](https://github.com/awslabs/aws-code-habits) submodule under `habits/`:
 
-## 🔍 Prerequisites
+```bash
+git clone --recurse-submodules https://github.com/awslabs/aws-terraform-dev-container.git
+```
 
-- [Docker](https://www.docker.com/products/docker-desktop/) - Required for running containers
-- [Visual Studio Code](https://code.visualstudio.com/) - The recommended IDE
-- [VS Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) - Required for Dev Containers
+To clone over SSH:
 
----
+```bash
+git clone --recurse-submodules git@github.com:awslabs/aws-terraform-dev-container.git
+```
 
-## 🚀 Getting Started
+If you already cloned the repository without `--recurse-submodules`, initialize the submodule:
 
-### Quick Start
+```bash
+git submodule update --init --recursive
+```
 
-1. Clone this repository:
-   ```bash
-   git clone https://github.com/awslabs/aws-terraform-dev-container.git
-   # or with SSH
-   git clone git@github.com:awslabs/aws-terraform-dev-container.git
-   ```
+### Add the container to an existing project
 
-2. Open the folder in VS Code:
+From the root of an existing Terraform project, run the bootstrap script. It copies the `.devcontainer/` directory into your project and adds `aws-code-habits` as a submodule (or a plain clone if the directory is not a Git repository):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/awslabs/aws-terraform-dev-container/main/scripts/init.sh | bash
+```
+
+Review [`scripts/init.sh`](scripts/init.sh) before you run it.
+
+## Getting started
+
+1. Open the project folder in VS Code:
+
    ```bash
    code aws-terraform-dev-container
    ```
 
-3. When prompted, click "Reopen in Container" or use the command palette (F1) and select "Remote-Containers: Reopen in Container"
+2. When VS Code prompts you, select **Reopen in Container**. You can also open the command palette (`F1`) and run **Dev Containers: Reopen in Container**.
 
-4. Wait for the container to build and initialize (this may take a few minutes the first time)
+3. Wait for the container to build. The first build downloads the base image and installs the tools, which can take several minutes.
 
-5. Start developing with all tools pre-configured and ready to use!
+4. When the container starts, the post-start command clears the terminal and prints the installed tool versions, the working directory, and authentication hints.
 
-<img src="doc/images/screenshot-1.gif" alt="Dev Container in Action" width="600"/>
+<img src="doc/images/screenshot-1.gif" alt="Dev container in action" width="600"/>
 
-### Recommended Workflow
+Once the container is running, authenticate to a cloud provider and initialize Terraform:
 
-1. **Initialize your project**: Use VS Code tasks to run `terraform init`
-2. **Install pre-commit hooks**: Run `pre-commit install` to set up automated validation
-3. **Develop iteratively**: Make small changes and validate frequently
-4. **Validate changes**: Use the pre-configured tasks for linting, security scanning, and validation
-5. **Generate documentation**: Use terraform-docs to keep documentation up-to-date
-6. **Estimate costs**: Run Infracost before applying changes to understand cost implications
-7. **Test your infrastructure**: Use Terratest to write and run tests for your infrastructure
-8. **Review and apply**: After thorough validation, apply your changes to the target environment
-
-### Project Structure Best Practices
-
-We recommend organizing your Terraform projects like this:
-
-```
-project/
-├── environments/
-│   ├── dev/
-│   │   ├── main.tf
-│   │   ├── variables.tf
-│   │   └── terraform.tfvars
-│   ├── staging/
-│   │   └── ...
-│   └── prod/
-│       └── ...
-├── modules/
-│   ├── networking/
-│   ├── compute/
-│   └── storage/
-└── tests/
-    └── ...
+```bash
+.devcontainer/scripts/aws-auth.sh
+terraform init
 ```
 
-This structure promotes code reuse, environment isolation, and easier testing.
+For a full walkthrough, see [USAGE.md](USAGE.md).
 
----
+## Usage
 
-## 🔧 Tools
+You run Terraform and its supporting tools from the integrated terminal, or through VS Code tasks. To run a task, open the command palette (`Ctrl+Shift+P`, or `Cmd+Shift+P` on macOS), select **Tasks: Run Task**, then choose a task.
 
-| Tool | Version | Description |
-|------|---------|-------------|
-| Terraform | 1.12.1 | Infrastructure as Code tool |
-| AWS CLI | 2.27.26 | Command line interface for AWS |
-| Azure CLI | Latest | Command line interface for Azure |
-| Google Cloud SDK | Latest | Command line interface for GCP |
-| terraform-docs | 0.20.0 | Documentation generator for Terraform modules |
-| tflint | 0.48.0 | Terraform linter |
-| tfsec | 1.28.13 | Security scanner for Terraform code |
-| terrascan | 1.19.9 | Detect compliance and security violations |
-| terragrunt | 0.50.1 | Thin wrapper for Terraform that provides extra tools |
-| terratest | v0.49.0 | Testing utility for infrastructure code |
-| infracost | 0.10.41 | Cloud cost estimates for Terraform |
-| checkov | 3.2.439 | Static code analysis tool for IaC |
-| pre-commit | Latest | Framework for managing git pre-commit hooks |
+The container defines these tasks in [`.vscode/tasks.json`](.vscode/tasks.json):
 
----
+| Task | Command |
+| --- | --- |
+| Terraform: Init | `terraform init` |
+| Terraform: Plan | `terraform plan -out=tfplan` |
+| Terraform: Apply | `terraform apply tfplan` |
+| Terraform: Apply (Auto-approve) | `terraform apply -auto-approve` |
+| Terraform: Destroy | `terraform destroy` |
+| Terraform: Validate | `terraform validate` |
+| Terraform: Format | `terraform fmt -recursive` |
+| Terraform: Clean | Remove `.terraform/`, the lock file, state files, and `tfplan` |
+| TFLint: Run | `tflint` |
+| TFSec: Run | `tfsec .` |
+| Checkov: Run | `checkov -d .` |
+| Pre-commit: Run All Hooks | `pre-commit run --all-files` |
+| AWS: Login | `.devcontainer/scripts/aws-auth.sh` |
+| AWS: Login with SSO | `.devcontainer/scripts/aws-auth.sh --sso` |
+| Azure: Login | `.devcontainer/scripts/azure-auth.sh` |
+| GCP: Login | `.devcontainer/scripts/gcp-auth.sh` |
 
-## 🔐 Authentication
-
-The container includes helper scripts for authenticating with each cloud provider:
-
-### AWS Authentication
+To authenticate to a cloud provider from the terminal, run the matching helper script:
 
 ```bash
 .devcontainer/scripts/aws-auth.sh [--profile PROFILE] [--region REGION] [--sso]
-```
-
-### Azure Authentication
-
-```bash
-.devcontainer/scripts/azure-auth.sh [--subscription SUBSCRIPTION_ID] [--tenant TENANT_ID] [--service-principal] [--client-id CLIENT_ID] [--client-secret CLIENT_SECRET]
-```
-
-### GCP Authentication
-
-```bash
+.devcontainer/scripts/azure-auth.sh [--subscription SUBSCRIPTION_ID] [--tenant TENANT_ID] [--service-principal --client-id CLIENT_ID --client-secret CLIENT_SECRET]
 .devcontainer/scripts/gcp-auth.sh [--project PROJECT_ID] [--credentials FILE_PATH]
 ```
 
----
-
-## 📋 VS Code Tasks
-
-The environment includes pre-configured VS Code tasks for common operations:
-
-- **Terraform: Init** - Initialize a Terraform working directory
-- **Terraform: Plan** - Generate and show an execution plan
-- **Terraform: Apply** - Build or change infrastructure
-- **Terraform: Destroy** - Destroy Terraform-managed infrastructure
-- **Terraform: Validate** - Validate the Terraform files
-- **Terraform: Format** - Rewrite Terraform configuration files to canonical format
-- **TFLint: Run** - Run TFLint for static analysis
-- **TFSec: Run** - Run TFSec for security scanning
-- **Checkov: Run** - Run Checkov for compliance checks
-- **Pre-commit: Run All Hooks** - Run all pre-commit hooks
-
-To run a task, press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS) and select "Tasks: Run Task", then choose the task you want to run.
-
----
-
-## 🔄 Pre-commit Hooks
-
-The environment includes pre-configured pre-commit hooks for Terraform validation, formatting, and security scanning. To install the hooks:
+To install the pre-commit hooks in your repository:
 
 ```bash
 pre-commit install
 ```
 
----
+For the complete usage reference — the Terraform workflow, multi-environment patterns, and pre-commit hooks — see [USAGE.md](USAGE.md). For the `make` targets inherited from `aws-code-habits`, see [Makefile.md](Makefile.md).
 
-## ⚙️ Configuration
+## Configuration
 
-### Environment Variables
+### Tool versions
 
-Environment variables for Terraform and cloud providers can be configured in `.devcontainer/config/terraform.env`. The following variables are available:
+Tool versions are pinned as build arguments in [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) and the [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile). To change a version, edit the corresponding build argument and rebuild the container (**Dev Containers: Rebuild Container**). The repository ships these versions:
 
-#### Terraform Configuration
+| Tool | Version | Description |
+| --- | --- | --- |
+| Terraform | 1.12.1 | Infrastructure as code tool. |
+| AWS CLI | v2 | Command line interface for AWS. |
+| Azure CLI | OS-provided (apt) [^1] | Command line interface for Azure. |
+| Google Cloud SDK | OS-provided (apt) [^2] | Command line interface for GCP. |
+| terraform-docs | 0.20.0 | Documentation generator for Terraform modules. |
+| tflint | 0.48.0 | Terraform linter. |
+| tfsec | 1.28.13 | Security scanner for Terraform code. |
+| terrascan | 1.19.9 | Compliance and security violation detector. |
+| terragrunt | 0.50.1 | Wrapper that adds tooling around Terraform. |
+| Terratest | 0.49.0 | Go testing library for infrastructure code. |
+| infracost | 0.10.41 | Cost estimates for Terraform. |
+| checkov | 3.2.439 | Static analysis for infrastructure as code. |
+| pre-commit | Latest (pip) [^3] | Framework for managing Git pre-commit hooks. |
 
-- `TF_PLUGIN_CACHE_DIR` - Directory for caching Terraform plugins
-- `TF_CLI_ARGS_init` - Arguments for `terraform init`
-- `TF_CLI_ARGS_plan` - Arguments for `terraform plan`
-- `TF_CLI_ARGS_apply` - Arguments for `terraform apply`
-- `TF_LOG` - Terraform logging level
+[^1]: Installed from Microsoft's official apt repository. See [Install the Azure CLI on Linux](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux).
+[^2]: Installed from Google Cloud's official apt repository. See [Install the gcloud CLI](https://cloud.google.com/sdk/docs/install#deb).
+[^3]: Installed with `pip install pre-commit` during the container build. To pin a version, edit `.devcontainer/library-scripts/common-utils.sh`.
 
-#### AWS Provider Configuration
+### Environment variables
 
-- `AWS_PROFILE` - AWS profile to use
-- `AWS_REGION` - AWS region to use
-- `AWS_SDK_LOAD_CONFIG` - Load config from AWS config file
+You configure Terraform and cloud-provider environment variables in [`.devcontainer/config/terraform.env`](.devcontainer/config/terraform.env). The post-start command sources this file when the container starts. The file ships with the Terraform variables set and the cloud-provider variables commented out:
 
-#### Azure Provider Configuration
+- Terraform: `TF_PLUGIN_CACHE_DIR`, `TF_CLI_ARGS_init`, `TF_CLI_ARGS_plan`, `TF_CLI_ARGS_apply`, `TF_LOG`.
+- AWS: `AWS_PROFILE`, `AWS_REGION`, `AWS_SDK_LOAD_CONFIG`.
+- Azure: `ARM_SUBSCRIPTION_ID`, `ARM_TENANT_ID`, `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`.
+- GCP: `GOOGLE_APPLICATION_CREDENTIALS`, `CLOUDSDK_CORE_PROJECT`.
 
-- `ARM_SUBSCRIPTION_ID` - Azure subscription ID
-- `ARM_TENANT_ID` - Azure tenant ID
-- `ARM_CLIENT_ID` - Azure client ID
-- `ARM_CLIENT_SECRET` - Azure client secret
+The container also sets `TF_PLUGIN_CACHE_DIR` through the `containerEnv` block in `devcontainer.json`.
 
-#### GCP Provider Configuration
+### VS Code settings, extensions, and hooks
 
-- `GOOGLE_APPLICATION_CREDENTIALS` - Path to GCP service account key file
-- `CLOUDSDK_CORE_PROJECT` - GCP project ID
+- Edit `.vscode/settings.json` to change editor settings.
+- Edit the `customizations.vscode.extensions` list in `devcontainer.json` to change installed extensions.
+- Edit `.pre-commit-config.yaml` to change the pre-commit hooks.
+- Edit the `.devcontainer/Dockerfile` and add a script under `.devcontainer/library-scripts/` to install additional tools.
 
-### Customization
+## How it works
 
-#### Adding Custom Tools
+The container is built from `.devcontainer/Dockerfile`, which starts from a pinned Microsoft VS Code dev container base image (Ubuntu 22.04) and runs three library scripts:
 
-To add custom tools to the container, modify the `.devcontainer/Dockerfile` and add your installation commands.
+- `common-utils.sh` installs common packages and `pre-commit`.
+- `cloud-cli-tools.sh` installs the AWS, Azure, and GCP command line interfaces.
+- `terraform-tools.sh` installs Terraform and its ecosystem, verifying each binary download against a published SHA256 checksum.
 
-#### Customizing VS Code Settings
+The container mounts the host credential directories (`~/.aws`, `~/.azure`, `~/.config/gcloud`, `~/.ssh`) and a named Docker volume for the Terraform plugin cache. The `postStartCommand` runs `post-start`, which loads the environment variables and prints the welcome banner. The GitHub CLI and Git are added through dev container features.
 
-VS Code settings can be customized in `.vscode/settings.json`.
+For the original design plan, see [terraform-devcontainer-plan.md](terraform-devcontainer-plan.md).
 
-#### Customizing Pre-commit Hooks
+### Security considerations
 
-Pre-commit hooks can be customized in `.pre-commit-config.yaml`.
+- Credentials are mounted from the host rather than stored in the image.
+- Binary downloads in the build are verified against published SHA256 checksums (see `.devcontainer/library-scripts/terraform-tools.sh`).
+- The base image is pinned to a specific minor version rather than a floating tag, and third-party GitHub Actions used in continuous integration (CI) are pinned to commit SHAs.
+- Cloud-provider CLIs (Azure CLI, Google Cloud SDK) are installed from their vendors' official apt repositories with `signed-by=` keyrings.
+- Pre-commit hooks run security scanning and secret detection before code is committed.
 
----
+## Troubleshooting
 
-## 💻 Advanced Usage
+| Issue | Resolution |
+| --- | --- |
+| Docker is not running. | Start Docker on your host before you reopen the folder in the container. |
+| The container fails to build. | Increase the memory Docker is allowed to use, then rebuild. |
+| Authentication fails. | Confirm your credentials with `aws sts get-caller-identity`, `az account show`, or `gcloud auth list`. |
+| Volume mounts are empty. | Confirm the source directories (`~/.aws`, `~/.azure`, `~/.config/gcloud`, `~/.ssh`) exist on the host. |
+| `make` targets do not run. | Initialize the submodule with `git submodule update --init --recursive`. |
 
-<details>
-<summary>Click to expand Advanced Usage details</summary>
+To view the container build log, select the **Remote** indicator in the bottom-left corner of VS Code and choose **Show Container Log**. For more guidance, see the Troubleshooting section of [USAGE.md](USAGE.md).
 
-### Tool Integration
+## Contributing
 
-This development environment is designed with tool integration in mind. Here's how the tools work together:
+See [Contributing](CONTRIBUTING.md) for how to propose changes.
 
-1. **Development Flow**:
-   - Write Terraform code in VS Code with syntax highlighting and IntelliSense
-   - Use terraform fmt (via tasks or pre-commit) to maintain consistent formatting
-   - Validate syntax with terraform validate
-   - Check for best practices with tflint
-   - Generate documentation automatically with terraform-docs
+## Security
 
-2. **Security and Compliance Flow**:
-   - Scan for security issues with tfsec
-   - Check compliance with terrascan and checkov
-   - Detect secrets with pre-commit hooks
-   - All integrated into the pre-commit workflow
+See [Security](SECURITY.md) for how to report a vulnerability.
 
-3. **Testing Flow**:
-   - Write infrastructure tests with Terratest
-   - Validate infrastructure behavior before deployment
-   - Ensure infrastructure meets requirements
+## License
 
-4. **Deployment Flow**:
-   - Estimate costs with Infracost
-   - Plan changes with terraform plan
-   - Apply changes with terraform apply
-   - Manage complex deployments with Terragrunt
-
-### Extending the Environment
-
-You can extend this development environment to suit your specific needs:
-
-1. **Adding Custom Tools**:
-   - Modify the Dockerfile to add additional tools
-   - Add custom scripts to the scripts directory
-   - Configure additional VS Code extensions in devcontainer.json
-
-2. **Team Customization**:
-   - Fork this repository for your team
-   - Add team-specific configurations and tools
-   - Share custom modules and examples
-   - Configure team-specific pre-commit hooks
-
-3. **CI/CD Integration**:
-   - Use the same tools in your CI/CD pipelines
-   - Export configurations from the dev container to CI/CD
-   - Ensure consistency between development and automation
-
-</details>
-
----
-
-## 📊 Use Cases
-
-<details>
-<summary>Click to expand Use Cases</summary>
-
-### Enterprise Infrastructure Teams
-- Standardize development environments across large teams
-- Enforce security and compliance policies through built-in tools
-- Simplify onboarding of new team members
-- Ensure consistent practices across multiple cloud providers
-
-### DevOps Engineers
-- Rapidly prototype and test infrastructure changes
-- Validate changes before applying to production environments
-- Generate documentation automatically
-- Estimate costs before deploying resources
-
-### Cloud Architects
-- Design and test multi-cloud architectures
-- Validate designs against security best practices
-- Create reusable infrastructure modules
-- Document architecture decisions
-
-### Individual Developers
-- Learn Terraform and cloud infrastructure in a pre-configured environment
-- Experiment with different cloud providers without complex setup
-- Follow industry best practices from day one
-- Focus on code rather than tooling
-
-</details>
-
----
-
-## 📈 Productivity Benefits
-
-<details>
-<summary>Click to expand Productivity Benefits</summary>
-
-### Time Savings
-- **Environment Setup**: Save 4-8 hours per developer on initial setup
-- **Tool Updates**: Eliminate 1-2 hours per month maintaining tools
-- **Onboarding**: Reduce new team member onboarding from days to hours
-- **Troubleshooting**: Minimize environment-related issues that can waste hours of development time
-
-### Quality Improvements
-- **Consistent Validation**: Every code change is automatically validated
-- **Security Scanning**: Catch security issues before they reach production
-- **Documentation**: Automatically generate and maintain documentation
-- **Testing**: Verify infrastructure works as expected with integrated testing tools
-
-### Collaboration Enhancements
-- **Standardized Environment**: Everyone works with the same tools and versions
-- **Reproducible Results**: Eliminate "works on my machine" problems
-- **Knowledge Sharing**: Common toolset makes it easier to share techniques and solutions
-- **Cross-Platform**: Works the same way on Windows, macOS, and Linux
-
-</details>
-
----
-
-## 💾 Volume Mounts
-
-The container includes the following volume mounts:
-
-- `~/.aws` - AWS credentials and configuration
-- `~/.azure` - Azure credentials and configuration
-- `~/.config/gcloud` - GCP credentials and configuration
-- `~/.ssh` - SSH keys
-- `terraform-cache` - Terraform plugin cache
-
----
-
-## 🔒 Security Considerations
-
-- **Credential Isolation**: Credentials are mounted from the host to avoid storing them in the container
-- **Automated Scanning**: Pre-commit hooks include security scanning for Terraform code
-- **Secret Detection**: Automated detection is enabled to prevent committing sensitive information
-- **Compliance Checking**: Built-in tools validate infrastructure against compliance standards
-- **Least Privilege**: Authentication helpers encourage following least privilege principles
-
----
-
-## ❓ Troubleshooting
-
-### Common Issues
-
-1. **Docker not running**: Ensure Docker is running on your system
-2. **Permission issues**: Ensure you have the necessary permissions for the mounted volumes
-3. **Authentication failures**: Check your credentials and ensure they are properly configured
-4. **Resource constraints**: Increase Docker's allocated memory if container builds fail
-5. **Network issues**: Verify your network can access required repositories and cloud services
-
-### Logs
-
-Container logs can be viewed in VS Code by clicking on the "Remote" indicator in the bottom-left corner and selecting "Show Container Log".
-
----
-
-## ❓ Getting Help
-
-### Documentation and Resources
-
-- **Official Documentation**: Refer to the [USAGE.md](USAGE.md) file for detailed usage instructions
-- **Issue Tracker**: Report bugs or request features through the [GitHub Issues](https://github.com/awslabs/aws-terraform-dev-container/issues)
-- **Community Support**: Join discussions in the [Discussions](https://github.com/awslabs/aws-terraform-dev-container/discussions) section
-
-### Learning Resources
-
-- **Terraform Documentation**: [Terraform Docs](https://www.terraform.io/docs)
-- **AWS Documentation**: [AWS Docs](https://docs.aws.amazon.com/)
-- **Azure Documentation**: [Azure Docs](https://docs.microsoft.com/azure/)
-- **GCP Documentation**: [GCP Docs](https://cloud.google.com/docs)
-
----
-
-## 🤝 Contributing
-
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to this project.
-
----
-
-## 📜 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
----
-
-## 🔒 Security
-
-See [SECURITY.md](SECURITY.md) for details on reporting security issues.
+This project is licensed under the MIT-0 License. See [LICENSE](LICENSE) for details.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,64 +1,59 @@
-# Terraform Development Environment Usage Guide
+# Usage
 
-This document provides detailed usage instructions for the Terraform Development Environment.
+This guide describes how to work in the Terraform Development Environment dev container: opening it, running Terraform, authenticating to cloud providers, using pre-commit hooks and VS Code tasks, and resolving common problems. For an overview of the container and its tools, see [README.md](README.md).
 
-## Table of Contents
+## Open the dev container
 
-- [Getting Started](#getting-started)
-- [Working with Terraform](#working-with-terraform)
-- [Cloud Provider Authentication](#cloud-provider-authentication)
-- [Using Pre-commit Hooks](#using-pre-commit-hooks)
-- [VS Code Tasks and Extensions](#vs-code-tasks-and-extensions)
-- [Advanced Configuration](#advanced-configuration)
-- [Best Practices](#best-practices)
-- [Troubleshooting](#troubleshooting)
+1. Open the project folder in Visual Studio Code.
+2. When VS Code prompts you, select **Reopen in Container**. You can also open the command palette (`F1`) and run **Dev Containers: Reopen in Container**.
+3. Wait for the container to build and start.
 
-## Getting Started
+When the container starts, the post-start command clears the terminal and prints the installed tool versions, the working directory, and hints for authenticating to each cloud provider.
 
-### Opening the Dev Container
+After the container is running, complete the initial setup:
 
-1. Open VS Code in the project directory
-2. Click on the green icon in the bottom-left corner
-3. Select "Reopen in Container"
-4. Wait for the container to build and initialize
+1. Authenticate to a cloud provider (see [Authenticate to a cloud provider](#authenticate-to-a-cloud-provider)).
+2. Install the pre-commit hooks:
 
-### Initial Setup
+   ```bash
+   pre-commit install
+   ```
 
-Once the container is running, you'll see a welcome message with information about the installed tools and their versions. The following steps are recommended for initial setup:
+3. Initialize Terraform:
 
-1. Configure cloud provider authentication (see [Cloud Provider Authentication](#cloud-provider-authentication))
-2. Install pre-commit hooks: `pre-commit install`
-3. Initialize Terraform: `terraform init`
+   ```bash
+   terraform init
+   ```
 
-## Working with Terraform
+## Work with Terraform
 
-### Basic Terraform Workflow
+### Basic workflow
 
 ```bash
-# Initialize Terraform
+# Initialize the working directory
 terraform init
 
-# Format Terraform code
+# Format configuration files
 terraform fmt -recursive
 
-# Validate Terraform code
+# Validate the configuration
 terraform validate
 
-# Plan changes
+# Generate an execution plan
 terraform plan -out=tfplan
 
-# Apply changes
+# Apply the planned changes
 terraform apply tfplan
 
-# Destroy infrastructure
+# Destroy managed infrastructure
 terraform destroy
 ```
 
-### Using Terraform with Multiple Environments
+### Manage multiple environments
 
-You can use Terraform workspaces or directory structures to manage multiple environments:
+You manage multiple environments with Terraform workspaces or with a directory structure.
 
-#### Using Workspaces
+To use workspaces:
 
 ```bash
 # Create workspaces
@@ -72,13 +67,13 @@ terraform workspace list
 # Select a workspace
 terraform workspace select dev
 
-# Run Terraform commands in the selected workspace
+# Run commands in the selected workspace
 terraform plan -out=tfplan
 ```
 
-#### Using Directory Structure
+To use a directory structure:
 
-```
+```text
 project/
 ├── environments/
 │   ├── dev/
@@ -99,49 +94,51 @@ project/
     └── storage/
 ```
 
-### Using Terraform with Terragrunt
+### Use Terragrunt
 
-The environment includes Terragrunt for managing Terraform configurations:
+The container includes Terragrunt for managing Terraform configurations:
 
 ```bash
-# Initialize Terragrunt
+# Initialize
 terragrunt init
 
-# Plan changes
+# Plan
 terragrunt plan -out=tfplan
 
-# Apply changes
+# Apply
 terragrunt apply tfplan
 ```
 
-## Cloud Provider Authentication
+## Authenticate to a cloud provider
 
-### AWS Authentication
+The container includes a helper script for each cloud provider under `.devcontainer/scripts/`. Each script accepts `--help` to print its options.
+
+### AWS
 
 ```bash
-# Basic authentication
+# Interactive login
 .devcontainer/scripts/aws-auth.sh
 
-# Authentication with profile
+# Use a named profile
 .devcontainer/scripts/aws-auth.sh --profile myprofile
 
-# Authentication with region
+# Set a region
 .devcontainer/scripts/aws-auth.sh --region us-west-2
 
-# Authentication with SSO
+# Use AWS IAM Identity Center (SSO)
 .devcontainer/scripts/aws-auth.sh --sso
 ```
 
-### Azure Authentication
+### Azure
 
 ```bash
-# Basic authentication (interactive)
+# Interactive login
 .devcontainer/scripts/azure-auth.sh
 
-# Authentication with subscription
+# Set a subscription
 .devcontainer/scripts/azure-auth.sh --subscription 00000000-0000-0000-0000-000000000000
 
-# Authentication with service principal
+# Use a service principal
 .devcontainer/scripts/azure-auth.sh \
   --service-principal \
   --tenant 00000000-0000-0000-0000-000000000000 \
@@ -149,120 +146,106 @@ terragrunt apply tfplan
   --client-secret "your-client-secret"
 ```
 
-### GCP Authentication
+### GCP
 
 ```bash
-# Basic authentication (interactive)
+# Interactive login
 .devcontainer/scripts/gcp-auth.sh
 
-# Authentication with project
+# Set a project
 .devcontainer/scripts/gcp-auth.sh --project my-project-id
 
-# Authentication with service account key
+# Use a service account key
 .devcontainer/scripts/gcp-auth.sh --credentials /path/to/service-account-key.json
 ```
 
-## Using Pre-commit Hooks
+## Use pre-commit hooks
 
-### Installing Pre-commit Hooks
+Install the hooks in your repository:
 
 ```bash
 pre-commit install
 ```
 
-### Running Pre-commit Hooks Manually
+Run the hooks manually:
 
 ```bash
 # Run on all files
 pre-commit run --all-files
 
-# Run specific hook
+# Run a single hook
 pre-commit run terraform_fmt --all-files
 ```
 
-### Available Pre-commit Hooks
+The hooks are defined in `.pre-commit-config.yaml`. To see the exact set of hooks and their versions, read that file. The hooks cover Terraform formatting, validation, and documentation; static analysis with `tflint`, `tfsec`, and `checkov`; shell script checks; and secret detection.
 
-- `terraform_fmt`: Format Terraform files
-- `terraform_validate`: Validate Terraform files
-- `terraform_docs`: Generate documentation for Terraform modules
-- `terraform_tflint`: Run TFLint
-- `terraform_tfsec`: Run TFSec
-- `terraform_checkov`: Run Checkov
-- `shellcheck`: Check shell scripts
-- `gitleaks`: Detect secrets in code
+## Use VS Code tasks
 
-## VS Code Tasks and Extensions
+To run a task:
 
-### Running VS Code Tasks
+1. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS).
+2. Select **Tasks: Run Task**.
+3. Choose a task.
 
-1. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS)
-2. Select "Tasks: Run Task"
-3. Choose the task you want to run
+The container defines these tasks in `.vscode/tasks.json`:
 
-### Available VS Code Tasks
+| Task | Command |
+| --- | --- |
+| Terraform: Init | `terraform init` |
+| Terraform: Plan | `terraform plan -out=tfplan` |
+| Terraform: Apply | `terraform apply tfplan` |
+| Terraform: Apply (Auto-approve) | `terraform apply -auto-approve` |
+| Terraform: Destroy | `terraform destroy` |
+| Terraform: Validate | `terraform validate` |
+| Terraform: Format | `terraform fmt -recursive` |
+| Terraform: Clean | Remove `.terraform/`, the lock file, state files, and `tfplan` |
+| TFLint: Run | `tflint` |
+| TFSec: Run | `tfsec .` |
+| Checkov: Run | `checkov -d .` |
+| Pre-commit: Run All Hooks | `pre-commit run --all-files` |
+| AWS: Login | `.devcontainer/scripts/aws-auth.sh` |
+| AWS: Login with SSO | `.devcontainer/scripts/aws-auth.sh --sso` |
+| Azure: Login | `.devcontainer/scripts/azure-auth.sh` |
+| GCP: Login | `.devcontainer/scripts/gcp-auth.sh` |
 
-- **Terraform: Init** - Initialize a Terraform working directory
-- **Terraform: Plan** - Generate and show an execution plan
-- **Terraform: Apply** - Build or change infrastructure
-- **Terraform: Destroy** - Destroy Terraform-managed infrastructure
-- **Terraform: Validate** - Validate the Terraform files
-- **Terraform: Format** - Rewrite Terraform configuration files to canonical format
-- **TFLint: Run** - Run TFLint for static analysis
-- **TFSec: Run** - Run TFSec for security scanning
-- **Checkov: Run** - Run Checkov for compliance checks
-- **Pre-commit: Run All Hooks** - Run all pre-commit hooks
-- **AWS: Login** - Login to AWS
-- **Azure: Login** - Login to Azure
-- **GCP: Login** - Login to GCP
+The installed VS Code extensions are listed in the `customizations.vscode.extensions` block of `.devcontainer/devcontainer.json`. They include HashiCorp Terraform, Azure Terraform, Terraform doc snippets, YAML support, GitLens, Git History, Git Graph, the Azure Tools pack, the Remote Containers and Remote SSH extensions, Code Spell Checker, Markdown All in One, markdownlint, Prettier, ShellCheck, and the Python and Pylance extensions.
 
-### Installed VS Code Extensions
+## Advanced configuration
 
-- HashiCorp Terraform
-- Azure Terraform
-- Terraform doc snippets
-- YAML support
-- Git integration (GitLens, Git Graph, Git History)
-- Remote Containers
-- Code Spell Checker
-- Markdown All in One
-- And more...
+### Edit environment variables
 
-## Advanced Configuration
-
-### Customizing Environment Variables
-
-Edit `.devcontainer/config/terraform.env` to customize environment variables:
+Edit `.devcontainer/config/terraform.env` to change environment variables. The post-start command sources this file when the container starts. The shipped file sets the Terraform variables and leaves the cloud-provider variables commented out:
 
 ```bash
 # Terraform Configuration
 TF_PLUGIN_CACHE_DIR=/home/vscode/.terraform.d/plugin-cache
-TF_CLI_ARGS_init="--upgrade"
-TF_CLI_ARGS_plan="-compact-warnings"
-TF_CLI_ARGS_apply="-compact-warnings"
+TF_CLI_ARGS_init=""
+TF_CLI_ARGS_plan=""
+TF_CLI_ARGS_apply=""
+# Uncomment for debug logging
 # TF_LOG=DEBUG
 
 # AWS Provider Configuration
-AWS_PROFILE=default
-AWS_REGION=us-west-2
-AWS_SDK_LOAD_CONFIG=1
+# AWS_PROFILE=default
+# AWS_REGION=us-west-2
+# AWS_SDK_LOAD_CONFIG=1
 
 # Azure Provider Configuration
-ARM_SUBSCRIPTION_ID=your-subscription-id
-ARM_TENANT_ID=your-tenant-id
-ARM_CLIENT_ID=your-client-id
-ARM_CLIENT_SECRET=your-client-secret
+# ARM_SUBSCRIPTION_ID=your-subscription-id
+# ARM_TENANT_ID=your-tenant-id
+# ARM_CLIENT_ID=your-client-id
+# ARM_CLIENT_SECRET=your-client-secret
 
 # GCP Provider Configuration
-GOOGLE_APPLICATION_CREDENTIALS=/home/vscode/.config/gcloud/application_default_credentials.json
-CLOUDSDK_CORE_PROJECT=your-project-id
+# GOOGLE_APPLICATION_CREDENTIALS=/home/vscode/.config/gcloud/application_default_credentials.json
+# CLOUDSDK_CORE_PROJECT=your-project-id
 ```
 
-### Customizing TFLint Rules
+### Customize TFLint rules
 
-Edit `.tflint.hcl` to customize TFLint rules:
+Edit `.tflint.hcl` to change TFLint rules:
 
 ```hcl
-# Enable or disable specific rules
 rule "terraform_deprecated_interpolation" {
   enabled = true
 }
@@ -271,111 +254,95 @@ rule "terraform_unused_declarations" {
   enabled = true
 }
 
-# Add custom rules
 rule "terraform_naming_convention" {
   enabled = true
-  format = "snake_case"
+  format  = "snake_case"
 }
 ```
 
-### Adding Custom Tools
+### Add a tool
 
-To add custom tools, create a new script in `.devcontainer/library-scripts/` and update the Dockerfile:
+To add a tool, create a script under `.devcontainer/library-scripts/` and call it from the Dockerfile:
 
 ```dockerfile
-# Install custom tool
 COPY library-scripts/custom-tool.sh /tmp/library-scripts/
 RUN chmod +x /tmp/library-scripts/custom-tool.sh
 RUN /tmp/library-scripts/custom-tool.sh
 ```
 
-## Best Practices
+## Best practices
 
-### Security Best Practices
+### Security
 
-1. **Never commit credentials**: Use environment variables or credential helpers
-2. **Regularly rotate credentials**: Especially for service accounts
-3. **Use least privilege**: Grant only the permissions needed
-4. **Enable MFA**: Use multi-factor authentication for cloud providers
-5. **Scan for secrets**: Use pre-commit hooks to detect secrets
+1. Never commit credentials. Use environment variables or credential helpers.
+2. Rotate credentials regularly, especially for service accounts.
+3. Grant only the permissions that are needed.
+4. Enable multi-factor authentication for cloud providers.
+5. Run the secret-detection pre-commit hook before you commit.
 
-### Terraform Best Practices
+### Terraform
 
-1. **Use modules**: Organize code into reusable modules
-2. **Version pinning**: Pin provider and module versions
-3. **Use remote state**: Store state in a remote backend
-4. **Use variables**: Parameterize your configurations
-5. **Document your code**: Use terraform-docs to generate documentation
+1. Organize code into reusable modules.
+2. Pin provider and module versions.
+3. Store state in a remote backend.
+4. Parameterize configurations with variables.
+5. Generate documentation with `terraform-docs`.
 
-### Development Workflow Best Practices
+### Development workflow
 
-1. **Use branches**: Create feature branches for changes
-2. **Run pre-commit hooks**: Validate code before committing
-3. **Review plans**: Always review Terraform plans before applying
-4. **Use workspaces or environments**: Separate development, staging, and production
-5. **Automate testing**: Use automated testing for Terraform code
+1. Create a feature branch for each change.
+2. Run pre-commit hooks before you commit.
+3. Review the plan before you apply.
+4. Separate development, staging, and production with workspaces or directories.
+5. Automate testing of your Terraform code.
 
 ## Troubleshooting
 
-### Common Issues and Solutions
+### Authentication fails
 
-#### Authentication Issues
-
-**Issue**: Unable to authenticate with cloud provider
-**Solution**: Check your credentials and ensure they are properly configured
+Confirm your credentials for each provider:
 
 ```bash
-# Check AWS credentials
+# AWS
 aws sts get-caller-identity
 
-# Check Azure credentials
+# Azure
 az account show
 
-# Check GCP credentials
+# GCP
 gcloud auth list
 ```
 
-#### Terraform Issues
+### `terraform init` fails
 
-**Issue**: Terraform init fails
-**Solution**: Check your backend configuration and credentials
+Check your backend configuration and credentials. Run with debug logging:
 
 ```bash
-# Initialize with debug logging
 TF_LOG=DEBUG terraform init
 ```
 
-**Issue**: Terraform plan/apply fails
-**Solution**: Check your provider configuration and credentials
+### `terraform plan` or `terraform apply` fails
+
+Check your provider configuration and credentials. Run with debug logging:
 
 ```bash
-# Plan with debug logging
 TF_LOG=DEBUG terraform plan
 ```
 
-#### Container Issues
+### The container fails to build
 
-**Issue**: Container fails to build
-**Solution**: Check Docker logs and ensure Docker has enough resources
+Check the Docker logs and confirm Docker has enough memory allocated:
 
 ```bash
-# Check Docker logs
 docker logs <container-id>
 ```
 
-**Issue**: Volume mounts not working
-**Solution**: Check permissions and ensure the directories exist on the host
+### Volume mounts are empty
+
+Confirm the source directories exist on the host and have the correct permissions:
 
 ```bash
-# Check permissions
 ls -la ~/.aws ~/.azure ~/.config/gcloud ~/.ssh
 ```
 
-### Getting Help
-
-If you encounter issues not covered in this guide, please:
-
-1. Check the documentation for the specific tool
-2. Search for the error message online
-3. Check the GitHub issues for this project
-4. Reach out to the community for help
+If a problem is not covered here, check the documentation for the specific tool and the [GitHub issues](https://github.com/awslabs/aws-terraform-dev-container/issues) for this project.

--- a/terraform-devcontainer-plan.md
+++ b/terraform-devcontainer-plan.md
@@ -1,8 +1,10 @@
-# Terraform Development Environment Plan
+# Terraform Development Environment design plan
+
+This document records the original design plan for the Terraform Development Environment dev container, which supports AWS, Microsoft Azure, and Google Cloud Platform (GCP). It is a historical design reference, not a description of the current state. For what the container ships today, see [README.md](README.md); for tool versions, see the configuration section of the README and `.devcontainer/devcontainer.json`.
 
 ## Overview
 
-This document outlines a comprehensive plan for creating a robust Terraform development environment using VS Code Dev Containers with support for AWS, Azure, and GCP.
+The plan describes a VS Code dev container for Terraform with a Dockerfile, a `devcontainer.json`, volume mounts, environment variables, pre-commit hooks, and VS Code tasks.
 
 ```mermaid
 flowchart TD
@@ -10,169 +12,137 @@ flowchart TD
     A --> C[devcontainer.json]
     A --> D[Volume Mounts]
     A --> E[Environment Variables]
-    
+
     B --> B1[Base Image]
     B --> B2[Cloud CLIs]
     B --> B3[Terraform Tools]
     B --> B4[Supporting Tools]
-    
+
     C --> C1[Extensions]
     C --> C2[Settings]
     C --> C3[Post-Start Commands]
     C --> C4[Mount Configurations]
-    
+
     E --> E1[AWS Auth]
     E --> E2[Azure Auth]
     E --> E3[GCP Auth]
-    
+
     F[Pre-commit Hooks] --> F1[Terraform Validation]
     F --> F2[Security Checks]
     F --> F3[Formatting]
-    
+
     G[VS Code Tasks] --> G1[Terraform Workflows]
     G --> G2[Cloud Provider Tasks]
 ```
 
-## 1. Dockerfile Configuration
+## Dockerfile
 
-### Base Image Selection
-- Use the official Microsoft VS Code Dev Container base image with Ubuntu 22.04 (jammy)
-- Include essential build tools and development libraries
+### Base image
 
-### Tool Installation
-- **Terraform CLI**: Latest stable version with version pinning
-- **Cloud Provider CLIs**:
-  - AWS CLI v2
-  - Azure CLI
-  - Google Cloud SDK
-- **Terraform Supporting Tools**:
-  - tflint (with AWS, Azure, and GCP rulesets)
-  - terraform-docs
-  - tfsec
-  - terrascan
-  - terragrunt
-  - infracost
-  - checkov
+- Use the official Microsoft VS Code dev container base image on Ubuntu 22.04 (jammy).
+- Include the build tools and development libraries the tool installers need.
 
-### Version Pinning Strategy
-- Pin all tool versions to specific releases for reproducibility
-- Include a mechanism to easily update versions when needed
+### Tools
 
-## 2. devcontainer.json Configuration
+- Terraform CLI, with version pinning.
+- Cloud-provider CLIs: AWS CLI v2, Azure CLI, and Google Cloud SDK.
+- Terraform supporting tools: `tflint` (with the AWS, Azure, and GCP rulesets), `terraform-docs`, `tfsec`, `terrascan`, `terragrunt`, `infracost`, and `checkov`.
+
+### Version pinning
+
+- Pin tool versions to specific releases for reproducible builds.
+- Provide a way to update versions when needed.
+
+## devcontainer.json
 
 ### Extensions
-- HashiCorp Terraform
-- Azure Terraform
-- Terraform doc snippets
-- YAML support
-- Git Graph
-- Git History
-- GitLens
-- Docker
-- Remote Containers
-- Code Spell Checker
-- Markdown All in One
+
+HashiCorp Terraform, Azure Terraform, Terraform doc snippets, YAML support, Git Graph, Git History, GitLens, Docker, Remote Containers, Code Spell Checker, and Markdown All in One.
 
 ### Settings
-- Configure Terraform formatting settings
-- Set up terminal profiles for each cloud provider
-- Configure editor settings for optimal Terraform development
+
+- Configure Terraform formatting.
+- Set up a terminal profile.
+- Configure editor settings for Terraform development.
 
 ### Features
-- Enable GitHub CLI
-- Configure Git with credential forwarding
 
-### Mount Configurations
-- Set up persistent volume mounts for:
-  - ~/.aws
-  - ~/.azure
-  - ~/.config/gcloud
-  - ~/.ssh
-  - ~/.terraform.d/plugin-cache
+- Enable the GitHub CLI.
+- Configure Git with credential forwarding.
 
-## 3. Pre-commit Hooks Configuration
+### Mounts
 
-### Terraform-specific Hooks
-- terraform fmt
-- terraform validate
-- terraform-docs
-- tflint
-- tfsec
-- checkov
+Set up persistent mounts for `~/.aws`, `~/.azure`, `~/.config/gcloud`, `~/.ssh`, and `~/.terraform.d/plugin-cache`.
 
-### General Code Quality Hooks
-- Trailing whitespace removal
-- End-of-file fixing
-- Large file checking
-- Merge conflict detection
-- YAML/JSON validation
+## Pre-commit hooks
 
-## 4. Environment Variables Configuration
+### Terraform hooks
 
-### AWS Authentication
-- AWS_PROFILE
-- AWS_REGION
-- AWS_SDK_LOAD_CONFIG
+`terraform fmt`, `terraform validate`, `terraform-docs`, `tflint`, `tfsec`, and `checkov`.
 
-### Azure Authentication
-- ARM_SUBSCRIPTION_ID
-- ARM_TENANT_ID
-- ARM_CLIENT_ID
-- ARM_CLIENT_SECRET (with secure handling)
+### General hooks
 
-### GCP Authentication
-- GOOGLE_APPLICATION_CREDENTIALS
-- CLOUDSDK_CORE_PROJECT
+Trailing-whitespace removal, end-of-file fixing, large-file checks, merge-conflict detection, and YAML/JSON validation.
 
-### Terraform Configuration
-- TF_PLUGIN_CACHE_DIR
-- TF_CLI_ARGS
-- TF_LOG (for debugging)
+## Environment variables
 
-## 5. VS Code tasks.json Configuration
+### AWS
 
-### Terraform Workflow Tasks
-- terraform init
-- terraform plan
-- terraform apply
-- terraform destroy
-- terraform validate
-- terraform fmt
+`AWS_PROFILE`, `AWS_REGION`, `AWS_SDK_LOAD_CONFIG`.
 
-### Cloud-specific Tasks
-- AWS login/logout
-- Azure login/logout
-- GCP login/logout
-- Cloud resource listing tasks
+### Azure
 
-## 6. Performance Optimization
+`ARM_SUBSCRIPTION_ID`, `ARM_TENANT_ID`, `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET` (handled securely).
 
-### Container Resource Allocation
-- Configure appropriate memory limits
-- Set CPU allocation based on host capabilities
+### GCP
 
-### Caching Strategies
-- Terraform plugin caching
-- Provider CLI caching
-- Docker layer optimization
+`GOOGLE_APPLICATION_CREDENTIALS`, `CLOUDSDK_CORE_PROJECT`.
 
-### Volume Mount Performance
-- Use delegated consistency for non-critical mounts
-- Use cached consistency for read-heavy directories
+### Terraform
 
-## 7. Security Considerations
+`TF_PLUGIN_CACHE_DIR`, `TF_CLI_ARGS`, `TF_LOG` (for debugging).
 
-### Credential Management
-- Use environment variables over hardcoded credentials
-- Implement credential helpers for cloud providers
-- Configure .gitignore for sensitive files
+## VS Code tasks
 
-### Secret Scanning
-- Implement pre-commit hooks for secret detection
-- Configure tfsec for security scanning
-- Set up checkov for compliance checking
+### Terraform workflow tasks
 
-## Implementation Approach
+`terraform init`, `terraform plan`, `terraform apply`, `terraform destroy`, `terraform validate`, and `terraform fmt`.
+
+### Cloud-provider tasks
+
+AWS, Azure, and GCP login, and cloud resource listing.
+
+## Performance
+
+### Resource allocation
+
+Set memory limits and CPU allocation based on the host's capabilities.
+
+### Caching
+
+Cache Terraform plugins and provider CLIs, and optimize Docker layers.
+
+### Volume mount performance
+
+Use delegated consistency for non-critical mounts and cached consistency for read-heavy directories.
+
+## Security
+
+### Credential management
+
+- Prefer environment variables over hardcoded credentials.
+- Use credential helpers for cloud providers.
+- Configure `.gitignore` for sensitive files.
+
+### Secret scanning
+
+- Add a pre-commit hook for secret detection.
+- Configure `tfsec` for security scanning.
+- Configure `checkov` for compliance checking.
+
+## Implementation timeline
+
+This timeline is part of the original plan and is kept for historical reference. The dates do not reflect the project's actual progress.
 
 ```mermaid
 gantt
@@ -192,9 +162,9 @@ gantt
     Validate functionality      :d2, after d1, 1d
 ```
 
-## File Structure
+## File structure
 
-```
+```text
 .devcontainer/
 ├── Dockerfile
 ├── devcontainer.json
@@ -217,12 +187,12 @@ gantt
 .pre-commit-config.yaml
 ```
 
-## Next Steps
+## Next steps
 
-1. Create the Dockerfile with all required tools and proper versioning
-2. Configure the devcontainer.json with extensions and settings
-3. Set up the persistent volume mounts for credentials and caching
-4. Implement the pre-commit hooks for Terraform validation
-5. Configure the environment variables for cloud provider authentication
-6. Create the VS Code tasks.json for common Terraform workflows
-7. Test and optimize the container performance
+1. Create the Dockerfile with the required tools and version pinning.
+2. Configure `devcontainer.json` with extensions and settings.
+3. Set up the persistent volume mounts for credentials and caching.
+4. Add the pre-commit hooks for Terraform validation.
+5. Configure the environment variables for cloud-provider authentication.
+6. Create `tasks.json` for the common Terraform workflows.
+7. Test and tune the container's performance.


### PR DESCRIPTION
## Summary

Rewrites the technical documentation for this repository to the shared AWS documentation style guide so it reads consistently with the rest of the AWS open-source fleet. Voice and mechanics: second person, present tense, active voice, no marketing language, sentence-case headings, language-hinted code blocks, and the required README section order. Content was verified against the source (`.devcontainer/`, `Makefile`, `.vscode/tasks.json`, scripts) so the docs describe what the container actually does today.

## Files rewritten

- **README.md** — Restructured to the required README skeleton: Overview, Features, Prerequisites, Installation, Getting started, Usage, Configuration, How it works (with security considerations), Troubleshooting, Contributing, Security, License. Accuracy corrections vs. the code:
  - Documented the full set of VS Code tasks, including `Terraform: Apply (Auto-approve)`, `AWS: Login with SSO`, and `Terraform: Clean`, which were missing before.
  - AWS CLI listed as v2 (it is installed by `cloud-cli-tools.sh`, not pinned in `devcontainer.json` build args).
  - Added the `scripts/init.sh` bootstrap as a second installation method.
  - Replaced the stars/MIT badges with an MIT-0 license badge (the repo is MIT-0).
- **USAGE.md** — Restyled as the usage reference (open the container, Terraform workflow, cloud authentication, pre-commit hooks, VS Code tasks, configuration, best practices, troubleshooting).
- **Makefile.md** — Restyled; preserved the real `make help` target catalog inherited from the `aws-code-habits` submodule, with a note that CI exercises only a subset.
- **terraform-devcontainer-plan.md** — Restyled as a historical design plan. Added a note that its tool list and dated implementation timeline are aspirational and do not reflect current state; the README is the source of truth for shipped behavior.

## Compliance

Compliance files (LICENSE, NOTICE, SECURITY.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, CHANGELOG.md) were not modified.

No branch protections or settings were changed.
