### PR TITLE
docs: add mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ The container also sets `TF_PLUGIN_CACHE_DIR` through the `containerEnv` block i
 
 ## How it works
 
+The following diagram shows how you go from opening the repository to a ready Terraform environment:
+
+```mermaid
+flowchart LR
+    Dev["Developer"] --> Code["VS Code + Dev Containers extension"]
+    Code -->|Reopen in Container| Build["Build image from .devcontainer/Dockerfile"]
+    Build --> Tools["Install Terraform, cloud CLIs, and supporting tools"]
+    Tools --> Start["postStartCommand runs post-start"]
+    Start --> Ready["Terraform environment ready"]
+    Ready --> Auth[".devcontainer/scripts/*-auth.sh"]
+    Ready --> Tf["terraform init, plan, apply"]
+```
+
 The container is built from `.devcontainer/Dockerfile`, which starts from a pinned Microsoft VS Code dev container base image (Ubuntu 22.04) and runs three library scripts:
 
 - `common-utils.sh` installs common packages and `pre-commit`.

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,6 +10,28 @@ This guide describes how to work in the Terraform Development Environment dev co
 
 When the container starts, the post-start command clears the terminal and prints the installed tool versions, the working directory, and hints for authenticating to each cloud provider.
 
+The following diagram shows how the running container is wired to the host. Credential directories are bind-mounted from the host, and the Terraform plugin cache is a named Docker volume:
+
+```mermaid
+flowchart TB
+    subgraph Host["Host"]
+        Creds["~/.aws, ~/.azure, ~/.config/gcloud, ~/.ssh"]
+        Cache["terraform-cache volume"]
+    end
+
+    subgraph Container["Dev container (Ubuntu 22.04)"]
+        Tools["Terraform + cloud CLIs + linting, security, and test tools"]
+        Scripts["aws-auth.sh, azure-auth.sh, gcp-auth.sh"]
+        Env["terraform.env environment variables"]
+    end
+
+    Creds -->|bind mount| Container
+    Cache -->|TF_PLUGIN_CACHE_DIR| Container
+    Scripts -->|read and write credentials| Creds
+    Env --> Tools
+    Tools -->|terraform init, plan, apply| Cloud["AWS, Azure, GCP"]
+```
+
 After the container is running, complete the initial setup:
 
 1. Authenticate to a cloud provider (see [Authenticate to a cloud provider](#authenticate-to-a-cloud-provider)).


### PR DESCRIPTION
## What

Adds GitHub-native mermaid diagrams to the documentation.

### Diagrams added

- **README.md** (`## How it works`): a left-to-right flow from the developer through VS Code and the Dev Containers extension, the image build from `.devcontainer/Dockerfile`, tool installation, the `postStartCommand` (`post-start`), and on to the cloud-auth helper scripts and the `terraform init`/`plan`/`apply` workflow.
- **USAGE.md** (`## Open the dev container`): a top-to-bottom architecture diagram of the running container, showing host credential directories bind-mounted in (`~/.aws`, `~/.azure`, `~/.config/gcloud`, `~/.ssh`), the `terraform-cache` named volume wired to `TF_PLUGIN_CACHE_DIR`, the in-container tooling and auth scripts, the `terraform.env` environment variables, and the Terraform workflow targeting AWS, Azure, and GCP.

Both diagrams reflect the actual `.devcontainer/` configuration (`devcontainer.json` mounts/`containerEnv`, the `Dockerfile` library scripts, `post-start.sh`, and the `scripts/*-auth.sh` helpers).

## Notes

- All mermaid diagrams validated locally with mermaid-cli (`mmdc`), including the two pre-existing diagrams in `terraform-devcontainer-plan.md`.
- Compliance files not modified (LICENSE, NOTICE, SECURITY.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, CHANGELOG.md).
- No branch protections or settings changed.
